### PR TITLE
Allowing maps scripts tag to be loaded after DOMContentLoaded event has fired.

### DIFF
--- a/lib/map-loader.js
+++ b/lib/map-loader.js
@@ -7,6 +7,7 @@
 var URL_PREFIX = '//maps.googleapis.com/maps/api/js',
     CALLBACK_IDENTIFIER = 'mapLoaded',
 
+    scriptLoaded = false,
     mapLoadedDeferred,
     mapLoadedPromise;
 
@@ -34,10 +35,16 @@ function createMapLoadedPromise() {
     });
 }
 
-function appendScriptOnDocumentReady(scriptEl) {
-    document.addEventListener('DOMContentLoaded', function () {
+function appendScriptWhenDocumentReady(scriptEl) {
+    if ( !scriptLoaded && document.readyState !== 'loading' ) {
         document.head.appendChild(scriptEl);
-    });
+        scriptLoaded = true;
+    } else {
+        document.addEventListener('DOMContentLoaded', function () {
+            document.head.appendChild(scriptEl);
+            scriptLoaded = true;
+        });
+    }
 }
 
 function injectGoogleMapsScript(options) {
@@ -45,7 +52,7 @@ function injectGoogleMapsScript(options) {
     scriptEl.src = buildUrl(options);
     scriptEl.type = 'text/javascript';
 
-    appendScriptOnDocumentReady(scriptEl);
+    appendScriptWhenDocumentReady(scriptEl);
 }
 
 function init() {


### PR DESCRIPTION
Making some changes to allow this module to work with server-rendered react components.

Problem: 
`componentWillMount` gets called server-side where google maps cannot be loaded. But, when `componentDidMount` gets called browser-side, the DOMContentLoaded event has already fired.

Fix:
Check `document.readyState` and add script immediately if it is not "loading" (meaning DOM is ready).
If readyState is loading, event listener is added like before and things function the same.
